### PR TITLE
Fix Npm error to lift up docker

### DIFF
--- a/website-ncraft/docker-compose.yml
+++ b/website-ncraft/docker-compose.yml
@@ -4,10 +4,9 @@ services:
     ports:
       - "3000:3000"
     volumes:
-     - .:/app
-     - ./node_modules:/app/node_modules
+      - .:/app
+      - ./node_modules:/app/node_modules
     environment:
       NODE_ENV: development
     stdin_open: true
     tty: true
-    command: npm start


### PR DESCRIPTION
Fixing the follow message error: "/docker-entrypoint.sh: exec: line 47: npm: not found", when I try to lift up the docker.